### PR TITLE
Use pod IP's if no CIDRs can be found from the node spec

### DIFF
--- a/telepresence/outbound/vpn.py
+++ b/telepresence/outbound/vpn.py
@@ -155,6 +155,13 @@ def podCIDRs(runner: Runner):
         )["items"]
     except CalledProcessError as e:
         runner.write("Failed to get nodes: {}".format(e))
+    else:
+        for node in nodes:
+            pod_cidr = node["spec"].get("podCIDR")
+            if pod_cidr is not None:
+                cidrs.add(pod_cidr)
+    
+    if len(cidrs) == 0:
         # Fallback to using pod IPs:
         pods = json.loads(
             runner.get_output(runner.kubectl("get", "pods", "-o", "json"))
@@ -168,11 +175,7 @@ def podCIDRs(runner: Runner):
                 pass
         if pod_ips:
             cidrs.add(covering_cidr(pod_ips))
-    else:
-        for node in nodes:
-            pod_cidr = node["spec"].get("podCIDR")
-            if pod_cidr is not None:
-                cidrs.add(pod_cidr)
+    
     return list(cidrs)
 
 


### PR DESCRIPTION
As detailed in #1201, node.spec.podCIDR is not a reliable source for CIDR's being used. I have updated the podCIDRs function to use get the pod IP's if no CIDRs are found from the node.spec.